### PR TITLE
Quick and dirty support for coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     },
 
     "dependencies": {
-        "mocha": "1.8"
+        "mocha": "~1.8",
+        "loghooks-node": "0.0.1"
     },
 
     "devDependencies": {

--- a/tasks/cafe_mocha.js
+++ b/tasks/cafe_mocha.js
@@ -11,6 +11,7 @@
 var Mocha = require('mocha'),
     path = require('path'),
     fs = require('fs'),
+    hook = require('loghooks-node'),
     Base = Mocha.reporters.base,
 
     cwd = process.cwd(),
@@ -73,7 +74,26 @@ module.exports = function(grunt) {
             });
         });
 
+        if (options.reporter === 'html-cov' || options.reporter === 'json-cov') {
+            hook.stdout(function (data) {
+                grunt.file.write(this.files[0].dest, data);
+            }.bind(this), false);
+        }
+
+        if (options.env) {
+            process.env[options.env] = 1;
+        }
+
         mocha.run(function (failures) {
+
+            if (options.reporter === 'html-cov' || options.reporter === 'json-cov') {
+                hook.unstdout();
+            }
+
+            if (options.env) {
+                delete process.env[options.env];
+            }
+
             if (failures) {
                 grunt.fail.warn('Mocha tests failed.');
             }


### PR DESCRIPTION
A really quick and dirty way of supporting code coverage tests.

```
cafemocha: {
    unit: {
        src: '<%= files.test %>',
        options: {
            ui: 'exports',
            reporter: 'nyan'
        }
    },
    coverage: {
        files: { 'coverage/index.html': '<%= cafemocha.unit.src %>'},
        options: {
            ui: 'exports',
            reporter: 'html-cov',
            env: 'JOHNNIE_COVERAGE'
        }
    }
}
```

it does by intercepting mocha's `stdout` and writing the info in the destination file, it also supports an environmental variable so that is possible to load the previously converted files for coverage analysis, just like specified [here](http://tjholowaychuk.com/post/18175682663/mocha-test-coverage)

_Note_: this doesn't run the [jscoverage](https://github.com/visionmedia/node-jscoverage) binary, I've chosen to do it with a separated task, since I believe that it distances itself from this tasks context.

Also this was really quick and dirty, you might want to do some tests first :worried:
