### PR TITLE
Fix slow parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The tiemout time for a test-case in milliseconds.
 #### options.slow
 Type: `Integer`
 
-Default value: `2000`
+Default value: `75`
 
 Threshold for a "slow" test in milliseconds.
 

--- a/tasks/cafe_mocha.js
+++ b/tasks/cafe_mocha.js
@@ -63,6 +63,7 @@ module.exports = function(grunt) {
         if (options.invert) mocha.invert();
         if (options.ignoreLeaks) mocha.ignoreLeaks();
         if (options.asyncOnly) mocha.asyncOnly();
+        if (options.slow) mocha.slow();
 
         if (options.colors === true) Base.useColors = true;
         else if (options.colors === false) Base.useColors = false;


### PR DESCRIPTION
Cafe-mocha does not actually pass along the `slow` parameter to mocha. If you add `options.slow` as a parameter to the grunt task, it does not actually have any effect on Mocha. I've updated the code to use `mocha.slow` and the README to match the default value in the code :)
