### PR TITLE
Allow for custom coverage reporters

### DIFF
--- a/tasks/cafe_mocha.js
+++ b/tasks/cafe_mocha.js
@@ -86,7 +86,9 @@ module.exports = function(grunt) {
 
         if (options.reporter === 'json-cov' || options.reporter === 'html-cov') {
             if (!options.coverage) return grunt.fail.warn('Coverage option not set.');
+        }
 
+        if (options.coverage) {
             // Check for coverage output file, else use default
             if (options.coverage.output) {
                 output = fs.createWriteStream(options.coverage.output, {flags: 'w'});


### PR DESCRIPTION
Currently, only the json-cov and html-cov reporters are supported for coverage.  This allows one to specify a custom reporter for coverage.
